### PR TITLE
Add Context as a configurable value

### DIFF
--- a/examples/twitter_login.go
+++ b/examples/twitter_login.go
@@ -23,6 +23,7 @@ func main() {
 	}
 
 	config = oauth1.Config{
+		Context:        oauth1.NoContext,
 		ConsumerKey:    consumerKey,
 		ConsumerSecret: consumerSecret,
 		CallbackURL:    outOfBand,

--- a/examples/twitter_request.go
+++ b/examples/twitter_request.go
@@ -20,7 +20,11 @@ func main() {
 		panic("Missing required environment variable")
 	}
 
-	config := oauth1.Config{ConsumerKey: consumerKey, ConsumerSecret: consumerSecret}
+	config := oauth1.Config{
+		Context:        oauth1.NoContext,
+		ConsumerKey:    consumerKey,
+		ConsumerSecret: consumerSecret,
+	}
 
 	// httpClient will automatically authorize http.Request's
 	httpClient := config.Client(oauth1.NoContext, accessToken, accessSecret)

--- a/internal/transport.go
+++ b/internal/transport.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"context"
 	"net/http"
+
+	"golang.org/x/net/context"
 )
 
 // HTTPClient is the context key to use with context's WithValue function

--- a/oauth1.go
+++ b/oauth1.go
@@ -2,7 +2,6 @@ package oauth1
 
 import (
 	"bytes"
-	"context"
 	"crypto/hmac"
 	"crypto/md5"
 	"crypto/sha1"
@@ -19,6 +18,7 @@ import (
 	"time"
 
 	"github.com/ktnyt/oauth1/internal"
+	"golang.org/x/net/context"
 )
 
 // NoContext is the default context you should supply if not using
@@ -30,6 +30,9 @@ var NoContext = context.TODO()
 // Config describes a typical OAuth1 flow, given a Consumer Key,
 // Consumer Secret, and a Callback URL.
 type Config struct {
+	// Context
+	Context context.Context
+
 	// Consumer Key (Client Identifier)
 	ConsumerKey string
 
@@ -89,7 +92,7 @@ func (c *Config) RequestToken() (string, string, error) {
 	req.Header.Add("Authorization", formatOAuthHeader(params))
 
 	// Request a request_token pair
-	res, err := internal.ContextClient(nil).Do(req)
+	res, err := internal.ContextClient(c.Context).Do(req)
 	if err != nil {
 		return "", "", err
 	}
@@ -177,7 +180,7 @@ func (c *Config) AccessToken(requestToken, requestSecret, verifier string) (stri
 	req.Header.Add("Authorization", formatOAuthHeader(params))
 
 	// Request an access_token pair
-	res, err := internal.ContextClient(nil).Do(req)
+	res, err := internal.ContextClient(c.Context).Do(req)
 	if err != nil {
 		return "", "", err
 	}

--- a/oauth1_test.go
+++ b/oauth1_test.go
@@ -15,7 +15,11 @@ const expectedVerifier = "some_verifier"
 func TestNewClient(t *testing.T) {
 	expectedToken := "access_token"
 	expectedConsumerKey := "consumer_key"
-	config := Config{ConsumerKey: expectedConsumerKey, ConsumerSecret: "consumer_secret"}
+	config := Config{
+		Context:        NoContext,
+		ConsumerKey:    expectedConsumerKey,
+		ConsumerSecret: "consumer_secret",
+	}
 	client := config.Client(NoContext, expectedToken, "access_secret")
 
 	server := newMockServer(func(w http.ResponseWriter, req *http.Request) {
@@ -29,7 +33,11 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewClient_DefaultTransport(t *testing.T) {
-	config := &Config{ConsumerKey: "t", ConsumerSecret: "s"}
+	config := &Config{
+		Context:        NoContext,
+		ConsumerKey:    "t",
+		ConsumerSecret: "s",
+	}
 	client := NewClient(NoContext, config.ConsumerKey, config.ConsumerSecret, "t", "s")
 	// assert that the client uses the DefaultTransport
 	transport, ok := client.Transport.(*Transport)
@@ -41,7 +49,11 @@ func TestNewClient_ContextClientTransport(t *testing.T) {
 	baseTransport := &http.Transport{}
 	baseClient := &http.Client{Transport: baseTransport}
 	ctx := context.WithValue(NoContext, HTTPClient, baseClient)
-	config := &Config{ConsumerKey: "t", ConsumerSecret: "s"}
+	config := &Config{
+		Context:        NoContext,
+		ConsumerKey:    "t",
+		ConsumerSecret: "s",
+	}
 	client := NewClient(ctx, config.ConsumerKey, config.ConsumerSecret, "t", "s")
 	// assert that the client uses the ctx client's Transport as its base RoundTripper
 	transport, ok := client.Transport.(*Transport)

--- a/reference_test.go
+++ b/reference_test.go
@@ -25,6 +25,7 @@ func TestTwitterRequestTokenAuthHeader(t *testing.T) {
 	expectedTimestamp := "1318467427"
 	expectedNonce := "ea9ec8429b68d6b77cd5600adbbb0456"
 	config := &Config{
+		Context:        NoContext,
 		ConsumerKey:    expectedConsumerKey,
 		ConsumerSecret: "L8qq9PZyRg6ieKGEKhZolGC0vJWLw8iEJ88DRdyOg",
 		CallbackURL:    "http://localhost/sign-in-with-twitter/",
@@ -69,6 +70,7 @@ func TestTwitterAccessTokenAuthHeader(t *testing.T) {
 	expectedTimestamp := "1318467427"
 	expectedNonce := "a9900fe68e2573b27a37f10fbad6a755"
 	config := &Config{
+		Context:        NoContext,
 		ConsumerKey:    expectedConsumerKey,
 		ConsumerSecret: "L8qq9PZyRg6ieKGEKhZolGC0vJWLw8iEJ88DRdyOg",
 		Endpoint: Endpoint{
@@ -111,6 +113,7 @@ var expectedTwitterConsumerKey = "xvz1evFS4wEEPTGEFPHBog"
 var expectedTwitterOAuthToken = "370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb"
 var expectedNonce = "kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg"
 var twitterConfig = &Config{
+	Context:        NoContext,
 	ConsumerKey:    expectedTwitterConsumerKey,
 	ConsumerSecret: "kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw",
 	Endpoint: Endpoint{


### PR DESCRIPTION
The configuration requires that a context is given, which is used when calling the authorization endpoints.